### PR TITLE
Dp 92 create header tables

### DIFF
--- a/data_profiler/data_profiler.py
+++ b/data_profiler/data_profiler.py
@@ -327,6 +327,7 @@ class DataProfiler:
             transform_response.message = message
             return transform_response
 
+        # NOTE: not updated with dp-92-create-header-tables. Not worth updating database, these aren't used anywhere
         uploaded_files = UploadedFilePaths(
             item_master = dir_validation_obj.item_master.file_path,
             inbound_header = dir_validation_obj.inbound_header.file_path if transform_options.process_inbound_data else '',

--- a/data_profiler/data_profiler_gui.py
+++ b/data_profiler/data_profiler_gui.py
@@ -19,6 +19,7 @@ from .helpers.models.ProjectInfo import BaseProjectInfo, ExistingProjectProjectI
 from .helpers.models.TransformOptions import DateForAnalysis, WeekendDateRules, TransformOptions
 from .helpers.models.Responses import TransformRowsInserted
 from .helpers.models.GeneralModels import DownloadDataOptions
+from .helpers.models.DataFiles import DataUploadType
 from .helpers.constants.app_constants import RESOURCES_DIR, RESOURCES_DIR_DEV
 from .frames.custom_widgets import ProjectInfoFrame, DataDirectoryFileSelectory, DataDescriberColumnSelector
 
@@ -29,7 +30,7 @@ from .data_profiler import DataProfiler
 from apex_gui.apex_app import ApexApp
 from apex_gui.frames.notification_dialogs import NotificationDialog, ResultsDialog, ResultsDialogWithLogFile, ConfirmDeleteDialog
 from apex_gui.frames.styled_widgets import Page, Section, SectionWithScrollbar, Frame, NeutralButton, TransparentIconButton, PositiveIconButton, NeutralIconButton, DangerIconButton
-from apex_gui.frames.custom_widgets import EntryWithLabel, StaticValueWithLabel, DropdownWithLabel, CheckbuttonWithLabel, FileBrowser
+from apex_gui.frames.custom_widgets import Toggle, StaticValueWithLabel, DropdownWithLabel, CheckbuttonWithLabel, FileBrowser
 from apex_gui.styles.fonts import AppSubtitleFont, SectionHeaderFont, SectionSubheaderFont
 from apex_gui.styles.colors import *
 from apex_gui.helpers.constants import EntryType
@@ -197,12 +198,13 @@ class DataProfilerGUI(ApexApp):
         self.upload_frame_title = CTkLabel(self.upload_frame_header_frame, text='Upload Project Data', font=AppSubtitleFont())
         self.upload_frame_back_to_home_btn = TransparentIconButton(self.upload_frame_header_frame, image=self.back_icon, command=self.navigate_to_home_action)
 
-        # LEVEL 2 - upload_frame_content_frame
+        # LEVEL 1 - upload_frame_content_frame
         self.upload_frame_upload_section = SectionWithScrollbar(self.upload_frame_content_frame, width=375, height=420)
         self.upload_frame_submit_btn = PositiveIconButton(self.upload_frame_content_frame, image=self.check_icon, command=self.upload_data_action)#, state='disabled')
 
-        # LEVEL 3 - upload_frame_upload_section
-        self.upload_frame_data_directory_browse = FileBrowser(self.upload_frame_upload_section, label_text='Select a data directory', path_type='folder')#, btn_action=self.validate_data_directory)
+        # LEVEL 2 - upload_frame_upload_section
+        self.upload_frame_data_directory_browse = FileBrowser(self.upload_frame_upload_section, label_text='Select a data directory', path_type='folder')
+        self.upload_frame_data_upload_type = Toggle(self.upload_frame_upload_section, on_value_text=DataUploadType.HEADERS.value, off_value_text=DataUploadType.REGULAR.value, default='off')
 
         self.upload_frame_date_for_analysis = DropdownWithLabel(self.upload_frame_upload_section, label_text='Date for Analysis', default_val=DateForAnalysis.PICK_DATE.value,
                                                                 dropdown_values=[DateForAnalysis.RECEIVED_DATE.value, DateForAnalysis.PICK_DATE.value, DateForAnalysis.SHIP_DATE.value],
@@ -427,14 +429,15 @@ class DataProfilerGUI(ApexApp):
         # LEVEL 2 - upload_frame_upload_section
         self.upload_frame_upload_section.grid_columnconfigure(0, weight=1)
 
-        self.upload_frame_data_directory_browse.grid(row=0, column=0, sticky='ew', padx=20, pady=(5, 20))
+        self.upload_frame_data_directory_browse.grid(row=0, column=0, sticky='ew', padx=20, pady=(5, 0))
+        self.upload_frame_data_upload_type.grid(row=1, column=0, padx=20, pady=(5, 20))
 
-        self.upload_frame_date_for_analysis.grid(row=1, column=0, sticky='ew', padx=20, pady=(20, 0))
-        self.upload_frame_weekend_date_rule.grid(row=2, column=0, sticky='ew', padx=20, pady=(20, 20))
+        self.upload_frame_date_for_analysis.grid(row=2, column=0, sticky='ew', padx=20, pady=(20, 0))
+        self.upload_frame_weekend_date_rule.grid(row=3, column=0, sticky='ew', padx=20, pady=(20, 20))
 
-        self.upload_frame_process_inbound_data.grid(row=3, column=0, sticky='ew', padx=20, pady=(20, 0))
-        self.upload_frame_process_inventory_data.grid(row=4, column=0, sticky='ew', padx=20, pady=(20, 0))
-        self.upload_frame_process_outbound_data.grid(row=5, column=0, sticky='ew', padx=20, pady=(20, 5))        
+        self.upload_frame_process_inbound_data.grid(row=4, column=0, sticky='ew', padx=20, pady=(20, 0))
+        self.upload_frame_process_inventory_data.grid(row=5, column=0, sticky='ew', padx=20, pady=(20, 0))
+        self.upload_frame_process_outbound_data.grid(row=6, column=0, sticky='ew', padx=20, pady=(20, 5))        
 
     def _grid_more_actions_frame(self):
         # Parent = self
@@ -606,36 +609,37 @@ class DataProfilerGUI(ApexApp):
                 data_dir_contents.append(file) 
 
 
-        # Have user select the columns to include
-        file_selector = DataDirectoryFileSelectory(self, files=data_dir_contents)
-        file_selector.attributes('-topmost', True)
-        self.wait_window(file_selector)
+        # # Have user select the columns to include
+        # file_selector = DataDirectoryFileSelectory(self, files=data_dir_contents)
+        # file_selector.attributes('-topmost', True)
+        # self.wait_window(file_selector)
 
-        # Run description, if user saved inputs
-        if not file_selector.get_saved():
-            return
+        # # Run description, if user saved inputs
+        # if not file_selector.get_saved():
+        #     return
         
-        # Validate inputs
-        success, message = file_selector.validate_inputs()
-        if not success:
-            # Display dialog
-            notification_dialog = NotificationDialog(self, title='Data Profiler', text=f'Data Describer ERROR:\n{message}')
-            notification_dialog.attributes('-topmost', True)
-            notification_dialog.mainloop()
-            return
+        # # Validate inputs
+        # success, message = file_selector.validate_inputs()
+        # if not success:
+        #     # Display dialog
+        #     notification_dialog = NotificationDialog(self, title='Data Profiler', text=f'Data Describer ERROR:\n{message}')
+        #     notification_dialog.attributes('-topmost', True)
+        #     notification_dialog.mainloop()
+        #     return
 
-        # Show loading frame while executing
-        self.show_loading_frame_action(f'Describing data...')
+        # # Show loading frame while executing
+        # self.show_loading_frame_action(f'Describing data...')
         
-        # Get user inputted values
-        selected_files = file_selector.get_selected_files()
-        print(selected_files)
-        input()
+        # # Get user inputted values
+        # selected_files = file_selector.get_selected_files()
+        # print(selected_files)
+        # input()
 
-        # Transform options don't need validation (cuz they're dropdowns and checkboxes)
+        # Transform options don't need validation (cuz they're dropdowns and checkboxes)       
         transform_options = TransformOptions(
             date_for_analysis=DateForAnalysis(self.upload_frame_date_for_analysis.get_variable_value()),
             weekend_date_rule=WeekendDateRules(self.upload_frame_weekend_date_rule.get_variable_value()),
+            data_upload_type=DataUploadType(self.upload_frame_data_upload_type.get_value()),
             process_inbound_data=self.upload_frame_process_inbound_data.get_value(),
             process_inventory_data=self.upload_frame_process_inventory_data.get_value(),
             process_outbound_data=self.upload_frame_process_outbound_data.get_value(),

--- a/data_profiler/frames/custom_widgets.py
+++ b/data_profiler/frames/custom_widgets.py
@@ -10,7 +10,6 @@ from customtkinter import CTkToplevel, CTkLabel
 
 # Data Profiler
 from ..helpers.models.ProjectInfo import BaseProjectInfo
-from ..helpers.models.DataFiles import UploadFileTypes
 
 # Apex GUI
 from apex_gui.frames.custom_widgets import EntryWithLabel, TextboxWithLabel, CheckbuttonWithLabel, DropdownWithLabel
@@ -18,6 +17,8 @@ from apex_gui.frames.styled_widgets import SectionWithScrollbar, Frame, Positive
 from apex_gui.helpers.constants import EntryType
 from apex_gui.styles.colors import *
 from apex_gui.styles.fonts import SectionSubheaderFont
+
+
 
 class ProjectInfoFrame(SectionWithScrollbar):
     '''
@@ -105,118 +106,6 @@ class ProjectInfoFrame(SectionWithScrollbar):
         self.salesperson.clear_input()
         self.start_date.clear_input()
         self.notes.clear_input()
-
-
-class DataDirectoryFileSelectory(CTkToplevel):
-    '''
-    Poo
-    '''
-
-    def __init__(self, master, files: list[str]):
-        super().__init__(master, fg_color=APEX_LIGHT_GRAY)
-
-        self.geometry('800x500')
-        self.title('Data Profiler')
-        
-        self.saved = False
-
-        ''' Widgets '''
-
-        # Parent = self
-        self.header_label = CTkLabel(self, text='Data Directory: Select Files', font=SectionSubheaderFont())        
-        self.body = SectionWithScrollbar(self)
-        self.footer = Frame(self)
-        
-        # Parent = body        
-        self.checkbuttons: dict[str, CheckbuttonWithLabel] = {}
-        for file in files:
-            label = CheckbuttonWithLabel(self.body, label_text=file, default_val=False)
-            self.checkbuttons[file] = label
-        self.set_checkbutton_defaults()
-
-        # Parent = footer
-        self.action_btns_frame = Frame(self.footer)
-
-        # Parent = btns_frame
-        self.save_btn = PositiveButton(self.action_btns_frame, text='Save', command=self.save_btn_action)
-
-        ''' Grid '''
-
-        # Parent = self
-        self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(1, weight=1)
-
-        self.header_label.grid(row=0, column=0)
-        self.body.grid(row=1, column=0, sticky='nsew', padx=20, pady=(0,20))
-        self.footer.grid(row=2, column=0)
-
-        # Parent = body
-        self.body.grid_columnconfigure(0, weight=1)
-
-        row = 1
-        for checkbutton in self.checkbuttons.values():
-            checkbutton.grid(row=row, column=0, pady=10)
-            row += 1
-
-        # Parent = footer
-        self.footer.grid_rowconfigure(0, weight=1)
-        self.footer.grid_columnconfigure(0, weight=1)
-
-        self.action_btns_frame.grid(row=0, column=0, pady=5)
-
-        # Parent = btns_frame
-        self.save_btn.grid(row=0, column=0)
-
-    def set_checkbutton_defaults(self):
-        if f'{UploadFileTypes.ITEM_MASTER.value}.csv' in self.checkbuttons.keys():
-            self.checkbuttons[f'{UploadFileTypes.ITEM_MASTER.value}.csv'].set_value(True)
-        
-        if f'{UploadFileTypes.INVENTORY.value}.csv' in self.checkbuttons.keys():
-            self.checkbuttons[f'{UploadFileTypes.INVENTORY.value}.csv'].set_value(True)
-
-        if f'{UploadFileTypes.INBOUND.value}.csv' in self.checkbuttons.keys():
-            self.checkbuttons[f'{UploadFileTypes.INBOUND.value}.csv'].set_value(True)
-        else:
-            if f'{UploadFileTypes.INBOUND_HEADER.value}.csv' in self.checkbuttons.keys():
-                self.checkbuttons[f'{UploadFileTypes.INBOUND_HEADER.value}.csv'].set_value(True)
-            if f'{UploadFileTypes.INBOUND_DETAILS.value}.csv' in self.checkbuttons.keys():
-                self.checkbuttons[f'{UploadFileTypes.INBOUND_DETAILS.value}.csv'].set_value(True)
-
-        if f'{UploadFileTypes.OUTBOUND.value}.csv' in self.checkbuttons.keys():
-            self.checkbuttons[f'{UploadFileTypes.OUTBOUND.value}.csv'].set_value(True)
-        else:
-            if f'{UploadFileTypes.ORDER_HEADER.value}.csv' in self.checkbuttons.keys():
-                self.checkbuttons[f'{UploadFileTypes.ORDER_HEADER.value}.csv'].set_value(True)
-            if f'{UploadFileTypes.ORDER_DETAILS.value}.csv' in self.checkbuttons.keys():
-                self.checkbuttons[f'{UploadFileTypes.ORDER_DETAILS.value}.csv'].set_value(True)
-
-    def get_selected_files(self):
-        selected_files = []
-        for file, label in self.checkbuttons.items():
-            if label.get_value():
-                selected_files.append(file)
-
-        return selected_files
-    
-    def validate_inputs(self) -> tuple[bool, str]:
-        selected_files = self.get_selected_files()
-
-        if len(selected_files) == 0:
-            return False, 'No files selected!'
-
-        
-
-        return True, ''
-
-    def save_btn_action(self):
-        self.set_saved(True)
-        self.destroy()
-
-    def get_saved(self):
-        return self.saved
-    
-    def set_saved(self, saved: bool):
-        self.saved = saved
 
 
 class DataDescriberColumnSelector(CTkToplevel):

--- a/data_profiler/frames/custom_widgets.py
+++ b/data_profiler/frames/custom_widgets.py
@@ -106,6 +106,92 @@ class ProjectInfoFrame(SectionWithScrollbar):
         self.notes.clear_input()
 
 
+class DataDirectoryFileSelectory(CTkToplevel):
+    '''
+    Poo
+    '''
+
+    def __init__(self, master, files: list[str]):
+        super().__init__(master, fg_color=APEX_LIGHT_GRAY)
+
+        self.geometry('800x500')
+        self.title('Data Profiler')
+        
+        self.saved = False
+
+        ''' Widgets '''
+
+        # Parent = self
+        self.header_label = CTkLabel(self, text='Data Directory: Select Files', font=SectionSubheaderFont())        
+        self.body = SectionWithScrollbar(self)
+        self.footer = Frame(self)
+        
+        # Parent = body        
+        self.checkbuttons: dict[str, CheckbuttonWithLabel] = {}
+        for file in files:
+            label = CheckbuttonWithLabel(self.body, label_text=file, default_val=True)
+            self.checkbuttons[file] = label
+
+        # Parent = footer
+        self.action_btns_frame = Frame(self.footer)
+
+        # Parent = btns_frame
+        self.save_btn = PositiveButton(self.action_btns_frame, text='Save', command=self.save_btn_action)
+
+        ''' Grid '''
+
+        # Parent = self
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(2, weight=1)
+
+        self.header_label.grid(row=0, column=0)
+        self.body.grid(row=1, column=0, sticky='nsew', padx=20, pady=(0,20))
+        self.footer.grid(row=2, column=0)
+
+        # Parent = body
+        self.body.grid_columnconfigure(0, weight=1)
+
+        row = 1
+        for checkbutton in self.checkbuttons.values():
+            checkbutton.grid(row=row, column=0, pady=10)
+            row += 1
+
+        # Parent = footer
+        self.footer.grid_rowconfigure(0, weight=1)
+        self.footer.grid_columnconfigure(0, weight=1)
+
+        self.action_btns_frame.grid(row=0, column=0, pady=5)
+
+        # Parent = btns_frame
+        self.save_btn.grid(row=0, column=0)
+
+    def get_selected_files(self):
+        selected_files = []
+        for file, label in self.checkbuttons.items():
+            if label.get_value():
+                selected_files.append(file)
+
+        return selected_files
+    
+    def validate_inputs(self) -> tuple[bool, str]:
+        selected_files = self.get_selected_files()
+
+        if len(selected_files) == 0:
+            return False, 'Select at least one file!'
+
+        return True, ''
+
+    def save_btn_action(self):
+        self.set_saved(True)
+        self.destroy()
+
+    def get_saved(self):
+        return self.saved
+    
+    def set_saved(self, saved: bool):
+        self.saved = saved
+
+
 class DataDescriberColumnSelector(CTkToplevel):
     '''
     Poo

--- a/data_profiler/frames/custom_widgets.py
+++ b/data_profiler/frames/custom_widgets.py
@@ -10,6 +10,7 @@ from customtkinter import CTkToplevel, CTkLabel
 
 # Data Profiler
 from ..helpers.models.ProjectInfo import BaseProjectInfo
+from ..helpers.models.DataFiles import UploadFileTypes
 
 # Apex GUI
 from apex_gui.frames.custom_widgets import EntryWithLabel, TextboxWithLabel, CheckbuttonWithLabel, DropdownWithLabel
@@ -129,8 +130,9 @@ class DataDirectoryFileSelectory(CTkToplevel):
         # Parent = body        
         self.checkbuttons: dict[str, CheckbuttonWithLabel] = {}
         for file in files:
-            label = CheckbuttonWithLabel(self.body, label_text=file, default_val=True)
+            label = CheckbuttonWithLabel(self.body, label_text=file, default_val=False)
             self.checkbuttons[file] = label
+        self.set_checkbutton_defaults()
 
         # Parent = footer
         self.action_btns_frame = Frame(self.footer)
@@ -142,7 +144,7 @@ class DataDirectoryFileSelectory(CTkToplevel):
 
         # Parent = self
         self.grid_columnconfigure(0, weight=1)
-        self.grid_rowconfigure(2, weight=1)
+        self.grid_rowconfigure(1, weight=1)
 
         self.header_label.grid(row=0, column=0)
         self.body.grid(row=1, column=0, sticky='nsew', padx=20, pady=(0,20))
@@ -165,6 +167,29 @@ class DataDirectoryFileSelectory(CTkToplevel):
         # Parent = btns_frame
         self.save_btn.grid(row=0, column=0)
 
+    def set_checkbutton_defaults(self):
+        if f'{UploadFileTypes.ITEM_MASTER.value}.csv' in self.checkbuttons.keys():
+            self.checkbuttons[f'{UploadFileTypes.ITEM_MASTER.value}.csv'].set_value(True)
+        
+        if f'{UploadFileTypes.INVENTORY.value}.csv' in self.checkbuttons.keys():
+            self.checkbuttons[f'{UploadFileTypes.INVENTORY.value}.csv'].set_value(True)
+
+        if f'{UploadFileTypes.INBOUND.value}.csv' in self.checkbuttons.keys():
+            self.checkbuttons[f'{UploadFileTypes.INBOUND.value}.csv'].set_value(True)
+        else:
+            if f'{UploadFileTypes.INBOUND_HEADER.value}.csv' in self.checkbuttons.keys():
+                self.checkbuttons[f'{UploadFileTypes.INBOUND_HEADER.value}.csv'].set_value(True)
+            if f'{UploadFileTypes.INBOUND_DETAILS.value}.csv' in self.checkbuttons.keys():
+                self.checkbuttons[f'{UploadFileTypes.INBOUND_DETAILS.value}.csv'].set_value(True)
+
+        if f'{UploadFileTypes.OUTBOUND.value}.csv' in self.checkbuttons.keys():
+            self.checkbuttons[f'{UploadFileTypes.OUTBOUND.value}.csv'].set_value(True)
+        else:
+            if f'{UploadFileTypes.ORDER_HEADER.value}.csv' in self.checkbuttons.keys():
+                self.checkbuttons[f'{UploadFileTypes.ORDER_HEADER.value}.csv'].set_value(True)
+            if f'{UploadFileTypes.ORDER_DETAILS.value}.csv' in self.checkbuttons.keys():
+                self.checkbuttons[f'{UploadFileTypes.ORDER_DETAILS.value}.csv'].set_value(True)
+
     def get_selected_files(self):
         selected_files = []
         for file, label in self.checkbuttons.items():
@@ -177,7 +202,9 @@ class DataDirectoryFileSelectory(CTkToplevel):
         selected_files = self.get_selected_files()
 
         if len(selected_files) == 0:
-            return False, 'Select at least one file!'
+            return False, 'No files selected!'
+
+        
 
         return True, ''
 

--- a/data_profiler/helpers/constants/data_file_constants.py
+++ b/data_profiler/helpers/constants/data_file_constants.py
@@ -10,17 +10,22 @@ Python constants relating to input/upload files for DataProfiler
 ''' Required Columns '''
 
 ITEM_MASTER_COLS = ['SKU','SKUDescription','SKUClass','ProductLine','UnitOfMeasure','EachLength','EachWidth','EachHeight','EachWeight','InnerQuantity','InnerLength','InnerWidth','InnerHeight','InnerWeight','CartonQuantity','CartonLength','CartonWidth','CartonHeight','CartonWeight','CartonsPerPallet','PalletTie','PalletHigh','MaxPalletStack','PalletLength','PalletWidth','PalletHeight','PalletWeight','Subwarehouse']
+INBOUND_COLS = ['PO_Number', 'SKU', 'UnitOfMeasure', 'Quantity', 'ArrivalDate', 'ArrivalTime', 'ExpectedDate', 'ExpectedTime', 'Carrier', 'Mode','ShipmentNumber', 'UnloadType', 'VendorID','SourcePoint']
+INVENTORY_COLS = ['Period','SKU','Quantity','UnitOfMeasure','Location','Lot', 'LPN','Subwarehouse']
+OUTBOUND_COLS = ['OrderNumber', 'SKU', 'UnitOfMeasure', 'PickType', 'Quantity', 'ReceivedDate','PickDate','ShipDate','Channel', 'BusinessUnit', 'ShipContainerType', 'SpecialHandlingCodes', 'Carrier']
+
 INBOUND_HEADER_COLS = ['PO_Number', 'ArrivalDate', 'ArrivalTime', 'ExpectedDate', 'ExpectedTime', 'Carrier', 'Mode','ShipmentNumber', 'UnloadType']
 INBOUND_DETAILS_COLS = ['PO_Number', 'SKU', 'UnitOfMeasure', 'Quantity', 'VendorID','SourcePoint']
-INVENTORY_COLS = ['Period','SKU','Quantity','UnitOfMeasure','Location','Lot', 'LPN','Subwarehouse']
 ORDER_HEADER_COLS = ['OrderNumber','ReceivedDate','PickDate','ShipDate','Channel']
 ORDER_DETAILS_COLS = ['OrderNumber','SKU', 'UnitOfMeasure', 'PickType', 'Quantity', 'BusinessUnit', 'ShipContainerType', 'SpecialHandlingCodes', 'Carrier']
 
 FILE_TYPES_COLUMNS_MAPPER = {
     'ItemMaster': ITEM_MASTER_COLS,
+    'Inbound': INBOUND_COLS,
+    'Inventory': INVENTORY_COLS,
+    'Outbound': OUTBOUND_COLS,
     'InboundHeader': INBOUND_HEADER_COLS,
     'InboundDetails': INBOUND_DETAILS_COLS,
-    'Inventory': INVENTORY_COLS,
     'OrderHeader': ORDER_HEADER_COLS,
     'OrderDetails': ORDER_DETAILS_COLS
 }
@@ -59,6 +64,23 @@ ITEM_MASTER_DTYPES = {
     'Subwarehouse':'object'
 }
 
+INBOUND_DTYPES = {
+    'PO_Number': 'object',
+    'SKU': 'object', 
+    'UnitOfMeasure': 'object', 
+    'Quantity': 'float64', 
+    'ArrivalDate': 'date', 
+    'ArrivalTime': 'time' , 
+    'ExpectedDate': 'date', 
+    'ExpectedTime': 'time', 
+    'Carrier': 'object', 
+    'Mode': 'object',
+    'ShipmentNumber': 'object',
+    'UnloadType': 'object',
+    'VendorID': 'object', 
+    'SourcePoint': 'object'
+}
+
 INBOUND_HEADER_DTYPES = {
     'PO_Number': 'object',
     'ArrivalDate': 'date', 
@@ -91,6 +113,22 @@ INVENTORY_DTYPES = {
     'Subwarehouse': 'object'
 }
 
+OUTBOUND_DTYPES = {
+    'OrderNumber':'object',
+    'SKU': 'object',
+    'UnitOfMeasure': 'object',
+    'PickType': 'object',
+    'Quantity': 'float64',
+    'ReceivedDate':'date',
+    'PickDate':'date',
+    'ShipDate':'date',
+    'Channel':'object',
+    'BusinessUnit': 'object', 
+    'ShipContainerType': 'object',
+    'SpecialHandlingCodes': 'object', 
+    'Carrier': 'object'
+}
+
 ORDER_HEADER_DTYPES = {
     'OrderNumber':'object',
     'ReceivedDate':'date',
@@ -113,9 +151,11 @@ ORDER_DETAILS_DTYPES = {
 
 FILE_TYPES_DTYPES_MAPPER = {
     'ItemMaster': ITEM_MASTER_DTYPES,
+    'Inbound': INBOUND_DTYPES,
+    'Inventory': INVENTORY_DTYPES,
+    'Outbound': OUTBOUND_DTYPES,
     'InboundHeader': INBOUND_HEADER_DTYPES,
     'InboundDetails': INBOUND_DETAILS_DTYPES,
-    'Inventory': INVENTORY_DTYPES,
     'OrderHeader': ORDER_HEADER_DTYPES,
     'OrderDetails': ORDER_DETAILS_DTYPES
 }
@@ -141,9 +181,11 @@ FILE_ERROR_MISSING_OUTBOUND_HEADER = '"Process Outbound Data" set to true but Ou
 FILE_ERROR_MISSING_OUTBOUND_DETAILS = '"Process Outbound Data" set to true but Outbound Details is not found.'
 
 FILE_ERROR_ITEM_MASTER_MISSING_COLUMNS = 'Item Master is missing columns.'
+FILE_ERROR_INBOUND_MISSING_COLUMNS = 'Inbound is missing columns.'
+FILE_ERROR_INVENTORY_MISSING_COLUMNS = 'Inventory is missing columns.'
+FILE_ERROR_OUTBOUND_MISSING_COLUMNS = 'Outbound is missing columns.'
 FILE_ERROR_INBOUND_HEADER_MISSING_COLUMNS = 'Inbound Header is missing columns.'
 FILE_ERROR_INBOUND_DETAILS_MISSING_COLUMNS = 'Inbound Details is missing columns.'
-FILE_ERROR_INVENTORY_MISSING_COLUMNS = 'Inventory is missing columns.'
 FILE_ERROR_ORDER_HEADER_MISSING_COLUMNS = 'Order Header is missing columns.'
 FILE_ERROR_ORDER_DETAILS_MISSING_COLUMNS = 'Order Details is missing columns.'
 

--- a/data_profiler/helpers/constants/data_file_constants.py
+++ b/data_profiler/helpers/constants/data_file_constants.py
@@ -174,9 +174,12 @@ DTYPES_DEFAULT_VALUES = {
 DIRECTORY_ERROR_DOES_NOT_EXIST = 'The given data directory does not exist.'
 
 FILE_ERROR_MISSING_ITEM_MASTER = 'Item Master is missing. Cannot continue.'
+FILE_ERROR_MISSING_INBOUND = '"Process Inbound Data" set to true but Inbound is not found.'
+FILE_ERROR_MISSING_INVENTORY = '"Process Inventory Data" set to true but Inventory file is not found.'
+FILE_ERROR_MISSING_OUTBOUND = '"Process Outbound Data" set to true but Outbound file is not found.'
+
 FILE_ERROR_MISSING_INBOUND_HEADER = '"Process Inbound Data" set to true but Inbound Header is not found.'
 FILE_ERROR_MISSING_INBOUND_DETAILS = '"Process Inbound Data" set to true but Inbound Details is not found.'
-FILE_ERROR_MISSING_INVENTORY = '"Process Inventory Data" set to true but Inventory file is not found.'
 FILE_ERROR_MISSING_OUTBOUND_HEADER = '"Process Outbound Data" set to true but Outbound Header is not found.'
 FILE_ERROR_MISSING_OUTBOUND_DETAILS = '"Process Outbound Data" set to true but Outbound Details is not found.'
 

--- a/data_profiler/helpers/data_directory.py
+++ b/data_profiler/helpers/data_directory.py
@@ -1,0 +1,435 @@
+'''
+Jack Miller
+Apex Companies
+Sep 2025
+'''
+
+from typing import Callable
+import os
+from io import TextIOWrapper
+import pandas as pd
+
+from ..helpers.functions.functions import validate_primary_keys, check_mismatching_primary_key_values
+from ..helpers.functions.data_file_functions import validate_file_structure, read_and_cleanse_uploaded_data_file
+from ..helpers.constants.data_file_constants import *
+
+from .models.DataFiles import DataDirectoryType, DataDirectoryValidation, UploadFileType, FileValidation
+from .models.TransformOptions import TransformOptions
+
+
+
+class DataDirectory:
+    '''
+    Used to track the contents and validity of a data directory for data uploads
+    '''
+
+    def __init__(self, path: str, transform_options: TransformOptions, update_progress_text_func: Callable[[str], None] = None):
+        self.path = path
+        self.directory_type = transform_options.data_directory_type
+        self.transform_options = transform_options
+        self.update_progress_text_func = update_progress_text_func
+
+        self.validation_obj = DataDirectoryValidation(file_path=self.path)
+
+        self.item_master = None
+        self.inbound_header = None
+        self.inbound_details = None
+        self.inventory = None
+        self.order_header = None
+        self.order_details = None
+
+    ''' Main Functions '''
+
+    def validate_directory(self) -> DataDirectoryValidation: 
+        '''
+        Validates a data directory. 
+
+        Valid data directory =  
+            1) All files are present  
+            2) those files have all required column headers
+        '''
+        
+        if not os.path.isdir(self.path):
+            self.validation_obj.errors_list.append(DIRECTORY_ERROR_DOES_NOT_EXIST)
+            self.validation_obj.is_valid = False
+
+            return self.validation_obj
+
+        self.validation_obj.data_directory_type = self.directory_type
+
+        ## Item Master
+
+        # Validate contents
+        self.validation_obj.item_master = self._validate_file_structure(file_type=UploadFileType.ITEM_MASTER)
+
+        # Error strings
+        if self.validation_obj.item_master.is_present:
+            self.validation_obj.given_files.append(UploadFileType.ITEM_MASTER.value)
+
+            if len(self.validation_obj.item_master.missing_columns) > 0:
+                error = f'{FILE_ERROR_ITEM_MASTER_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.item_master.missing_columns)}]'
+                self.validation_obj.errors_list.append(error)
+        else:
+            self.validation_obj.errors_list.append(FILE_ERROR_MISSING_ITEM_MASTER)
+
+        ## Inbound
+        if self.transform_options.process_inbound_data:            
+            if self.directory_type == DataDirectoryType.REGULAR:
+                # Validate contents
+                self.validation_obj.inbound = self._validate_file_structure(file_type=UploadFileType.INBOUND)
+
+                # Error strings
+                if self.validation_obj.inbound.is_present:
+                    self.validation_obj.given_files.append(UploadFileType.INBOUND.value)
+
+                    if len(self.validation_obj.inbound.missing_columns) > 0:
+                        error = f'{FILE_ERROR_INBOUND_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.inbound.missing_columns)}]'
+                        self.validation_obj.errors_list.append(error)
+                else:
+                    self.validation_obj.errors_list.append(FILE_ERROR_MISSING_INBOUND)  
+
+            else:
+                # Validate contents
+                self.validation_obj.inbound_header = self._validate_file_structure(file_type=UploadFileType.INBOUND_HEADER)
+                self.validation_obj.inbound_details = self._validate_file_structure(file_type=UploadFileType.INBOUND_DETAILS)
+
+                # Error strings
+                if self.validation_obj.inbound_header.is_present:
+                    self.validation_obj.given_files.append(UploadFileType.INBOUND_HEADER.value)
+
+                    if len(self.validation_obj.inbound_header.missing_columns) > 0:
+                        error = f'{FILE_ERROR_INBOUND_HEADER_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.inbound_header.missing_columns)}]'
+                        self.validation_obj.errors_list.append(error)
+                else:
+                    self.validation_obj.errors_list.append(FILE_ERROR_MISSING_INBOUND_HEADER)
+
+                # Inbound Details
+                if self.validation_obj.inbound_details.is_present:
+                    self.validation_obj.given_files.append(UploadFileType.INBOUND_DETAILS.value)
+
+                    if len(self.validation_obj.inbound_details.missing_columns) > 0:
+                        error = f'{FILE_ERROR_INBOUND_DETAILS_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.inbound_details.missing_columns)}]'
+                        self.validation_obj.errors_list.append(error)
+                else:
+                    self.validation_obj.errors_list.append(FILE_ERROR_MISSING_INBOUND_DETAILS)
+
+        ## Inventory
+        if self.transform_options.process_inventory_data:
+            # Validate contents
+            self.validation_obj.inventory = self._validate_file_structure(file_type=UploadFileType.INVENTORY)
+            
+            # Error strings
+            if self.validation_obj.inventory.is_present:
+                self.validation_obj.given_files.append(UploadFileType.INVENTORY.value)
+
+                if len(self.validation_obj.inventory.missing_columns) > 0:
+                    error = f'{FILE_ERROR_INVENTORY_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.inventory.missing_columns)}]'
+                    self.validation_obj.errors_list.append(error)
+            else:
+                self.validation_obj.errors_list.append(FILE_ERROR_MISSING_INVENTORY)
+
+        ## Outbound
+        if self.transform_options.process_outbound_data:
+            if self.directory_type == DataDirectoryType.REGULAR:
+                # Validate contents
+                self.validation_obj.outbound = self._validate_file_structure(file_type=UploadFileType.OUTBOUND)
+
+                # Error strings
+                if self.validation_obj.outbound.is_present:
+                    self.validation_obj.given_files.append(UploadFileType.OUTBOUND.value)
+
+                    if len(self.validation_obj.outbound.missing_columns) > 0:
+                        error = f'{FILE_ERROR_OUTBOUND_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.outbound.missing_columns)}]'
+                        self.validation_obj.errors_list.append(error)
+                else:
+                    self.validation_obj.errors_list.append(FILE_ERROR_MISSING_OUTBOUND)  
+            else:    
+                # Validate contents
+                self.validation_obj.order_header = self._validate_file_structure(file_type=UploadFileType.ORDER_HEADER)
+                self.validation_obj.order_details = self._validate_file_structure(file_type=UploadFileType.ORDER_DETAILS)
+                    
+                # Error strings
+                if self.validation_obj.order_header.is_present:
+                    self.validation_obj.given_files.append(UploadFileType.ORDER_HEADER.value)
+
+                    if len(self.validation_obj.order_header.missing_columns) > 0:
+                        error = f'{FILE_ERROR_ORDER_HEADER_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.order_header.missing_columns)}]'
+                        self.validation_obj.errors_list.append(error)
+                else:
+                    self.validation_obj.errors_list.append(FILE_ERROR_MISSING_OUTBOUND_HEADER)
+
+                # Order Details
+                if self.validation_obj.order_details.is_present:
+                    self.validation_obj.given_files.append(UploadFileType.ORDER_DETAILS.value)
+
+                    if len(self.validation_obj.order_details.missing_columns) > 0:
+                        error = f'{FILE_ERROR_ORDER_DETAILS_MISSING_COLUMNS}\n[{", ".join(self.validation_obj.order_details.missing_columns)}]'
+                        self.validation_obj.errors_list.append(error)
+                else:
+                    self.validation_obj.errors_list.append(FILE_ERROR_MISSING_OUTBOUND_DETAILS)
+
+        if len(self.validation_obj.errors_list) > 0:
+            self.validation_obj.is_valid = False
+            
+        return self.validation_obj
+    
+    def read_and_validate_file_contents(self, log_file: TextIOWrapper) -> tuple[bool, str]:
+        '''
+        Read files
+        '''
+        
+        if self.update_progress_text_func: self.update_progress_text_func('Reading data...')
+
+        ## Start
+        
+        log_file.write(f'1. READ IN UPLOADED FILES\n')
+        log_file.flush()
+
+        # Variables
+        valid_data = True
+
+        master_errors_dict = {}
+
+        item_master = None
+        inbound_header = None
+        inbound_details = None
+        inventory = None
+        order_header = None
+        order_details = None
+
+        IM_SKUS = []
+        IB_SKUS = []
+        INV_SKUS = []
+        OB_SKUS = []
+
+        IBH_RECEIPTS = []
+        IBD_RECEIPTS = []
+
+        OBH_ORDERS = []
+        OBD_ORDERS = []
+
+        ## Read files (and cleanse along the way)
+        
+        # If item master isn't present, error will already have come up
+        item_master, item_master_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.ITEM_MASTER, file_path=self.validation_obj.item_master.file_path, log_file=log_file)
+        print(item_master.head())
+        print(f'Errors reading item master: {", ".join(item_master_errors_list)}')
+        if (len(item_master_errors_list) > 0):
+            valid_data = False
+            master_errors_dict[UploadFileType.ITEM_MASTER.value] = item_master_errors_list
+        IM_SKUS = item_master['SKU'].unique().tolist()
+
+        if self.transform_options.process_inbound_data:
+            if self.directory_type == DataDirectoryType.REGULAR:
+                inbound, inbound_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.INBOUND, file_path=self.validation_obj.inbound.file_path, log_file=log_file)
+                print(inbound.head())
+                print(f'Errors reading inbound: {", ".join(inbound_errors_list)}')
+                if len(inbound_errors_list) > 0:
+                    valid_data = False
+                    master_errors_dict[UploadFileType.INBOUND.value] = inbound_errors_list
+
+                IB_SKUS = inbound['SKU'].unique().tolist()
+
+            else:
+                inbound_header, inbound_header_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.INBOUND_HEADER, file_path=self.validation_obj.inbound_header.file_path, log_file=log_file)
+                print(inbound_header.head())
+                print(f'Errors reading inbound header: {", ".join(inbound_header_errors_list)}')
+                if len(inbound_header_errors_list) > 0:
+                    valid_data = False
+                    master_errors_dict[UploadFileType.INBOUND_HEADER.value] = inbound_header_errors_list
+
+                inbound_details, inbound_details_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.INBOUND_DETAILS, file_path=self.validation_obj.inbound_details.file_path, log_file=log_file)
+                print(inbound_details.head())
+                print(f'Errors reading inbound details: {", ".join(inbound_details_errors_list)}')
+                if len(inbound_details_errors_list) > 0:
+                    valid_data = False
+                    master_errors_dict[UploadFileType.INBOUND_DETAILS.value] = inbound_details_errors_list
+
+                IB_SKUS = inbound_details['SKU'].unique().tolist()
+                IBH_RECEIPTS = inbound_header['PO_Number'].unique().tolist()
+                IBD_RECEIPTS = inbound_details['PO_Number'].unique().tolist()
+
+        if self.transform_options.process_inventory_data:
+            inventory, inventory_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.INVENTORY, file_path=self.validation_obj.inventory.file_path, log_file=log_file)
+            print(inventory.head())
+            print(f'Errors reading inventory: {", ".join(inventory_errors_list)}')
+            if len(inventory_errors_list) > 0:
+                valid_data = False
+                master_errors_dict[UploadFileType.INVENTORY.value] = inventory_errors_list
+
+            INV_SKUS = inventory['SKU'].unique().tolist()
+
+        if self.transform_options.process_outbound_data:
+            if self.directory_type == DataDirectoryType.REGULAR:
+                outbound, outbound_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.OUTBOUND, file_path=self.validation_obj.outbound.file_path, log_file=log_file)
+                print(outbound.head())
+                print(f'Errors reading outbound: {", ".join(outbound_errors_list)}')
+                if len(outbound_errors_list) > 0:
+                    valid_data = False
+                    master_errors_dict[UploadFileType.OUTBOUND.value] = outbound_errors_list
+                    
+                OB_SKUS = outbound['SKU'].unique().tolist()
+
+            else:
+                order_header, order_header_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.ORDER_HEADER, file_path=self.validation_obj.order_header.file_path, log_file=log_file)
+                print(order_header.head())
+                print(f'Errors reading order header: {", ".join(order_header_errors_list)}')
+                if len(order_header_errors_list) > 0:
+                    valid_data = False
+                    master_errors_dict[UploadFileType.ORDER_HEADER.value] = order_header_errors_list
+
+                order_details, order_details_errors_list = read_and_cleanse_uploaded_data_file(file_type=UploadFileType.ORDER_DETAILS, file_path=self.validation_obj.order_details.file_path, log_file=log_file)
+                print(order_details.head())
+                print(f'Errors reading order details: {", ".join(order_details_errors_list)}')
+                if len(order_details_errors_list) > 0:
+                    valid_data = False
+                    master_errors_dict[UploadFileType.ORDER_DETAILS.value] = order_details_errors_list
+
+                OB_SKUS = order_details['SKU'].unique().tolist()
+                OBH_ORDERS = order_header['OrderNumber'].unique().tolist()
+                OBD_ORDERS = order_details['OrderNumber'].unique().tolist()
+            
+        if not valid_data:
+            log_file.write(f'\nCritical issues reading the data. Cannot continue.\n')
+            log_file.close()
+
+            return False, f'ERROR - Some critical issues reading the data. Check log.'
+        
+
+        ## Validate files once they're read ##
+
+        if self.update_progress_text_func: self.update_progress_text_func('Validating file contents...')
+
+        # SKU Checks
+        bad_im_skus = validate_primary_keys(IM_SKUS)
+
+        if len(bad_im_skus) > 0:
+            valid_data = False
+            log_file.write(f'ERROR - Found {len(bad_im_skus)} erroneous Item Master SKUs\n')
+            log_file.write(f'{bad_im_skus[:10]}...\n')
+
+        bad_ib_skus = check_mismatching_primary_key_values(IM_SKUS, IB_SKUS)
+        bad_inv_skus = check_mismatching_primary_key_values(IM_SKUS, INV_SKUS)
+        bad_ob_skus = check_mismatching_primary_key_values(IM_SKUS, OB_SKUS)
+
+        if len(bad_ib_skus) > 0:
+            valid_data = False
+            log_file.write(f'ERROR - {len(bad_ib_skus)} Inbound{" Details" if self.directory_type == DataDirectoryType.HEADERS else ""} SKUs not in Item Master\n')
+            log_file.write(f'{bad_ib_skus[:10]}...\n')
+        
+        if len(bad_inv_skus) > 0:
+            valid_data = False
+            log_file.write(f'ERROR - {len(bad_inv_skus)} Inventory SKUs not in Item Master\n')
+            log_file.write(f'{bad_inv_skus[:10]}...\n')
+
+        if len(bad_ob_skus) > 0:
+            valid_data = False
+            log_file.write(f'ERROR - {len(bad_ob_skus)} {"Order Details" if self.directory_type == DataDirectoryType.HEADERS else "Outbound"} SKUs not in Item Master\n')
+            log_file.write(f'{bad_ob_skus[:10]}...\n')
+
+        # Receipt/Order Number Checks
+        if self.directory_type == DataDirectoryType.HEADERS:
+            bad_receipt_numbers = validate_primary_keys(IBH_RECEIPTS)
+            bad_order_numbers = validate_primary_keys(OBH_ORDERS)
+
+            if len(bad_receipt_numbers) > 0:
+                valid_data = False
+                log_file.write(f'ERROR - Found {len(bad_receipt_numbers)} erroneous Inbound Header receipt numbers\n')
+                log_file.write(f'{bad_receipt_numbers[:10]}...\n')
+
+            if len(bad_order_numbers) > 0:
+                valid_data = False
+                log_file.write(f'ERROR - Found {len(bad_order_numbers)} erroneous Order Header order numbers\n')
+                log_file.write(f'{bad_order_numbers[:10]}...\n')
+
+            bad_ibd_receipts = check_mismatching_primary_key_values(IBH_RECEIPTS, IBD_RECEIPTS)
+            bad_obd_receipts = check_mismatching_primary_key_values(OBH_ORDERS, OBD_ORDERS)
+            
+            if len(bad_ibd_receipts) > 0:
+                valid_data = False
+                log_file.write(f'ERROR - {len(bad_ibd_receipts)} Inbound Details receipt numbers not in Inbound Header\n')
+                log_file.write(f'{bad_ibd_receipts[:10]}...\n')
+
+            if len(bad_obd_receipts) > 0:
+                valid_data = False
+                log_file.write(f'ERROR - {len(bad_obd_receipts)} Order Details order numbers not in Order Header\n')
+                log_file.write(f'{bad_obd_receipts[:10]}...\n')
+
+        if not valid_data:
+            log_file.write(f'\nSome primary/foreign key issues. Cannot continue.\n')
+            log_file.close()
+
+            return False, f'ERROR - Found some primary/foreign key issues. Cannot continue. Check log.'
+        
+        ## Split to header / details if necessary
+        if self.directory_type == DataDirectoryType.REGULAR:
+            # Get headers
+            inbound_header = self._get_header_from_inbound_df(inbound_df=inbound)
+            order_header = self._get_header_from_outbound_df(outbound_df=outbound)
+
+            # Reindex
+            inbound_header = inbound_header.reindex(columns=FILE_TYPES_COLUMNS_MAPPER[UploadFileType.INBOUND_HEADER.value])
+            inbound_details = inbound.reindex(columns=FILE_TYPES_COLUMNS_MAPPER[UploadFileType.INBOUND_DETAILS.value])
+            order_header = order_header.reindex(columns=FILE_TYPES_COLUMNS_MAPPER[UploadFileType.ORDER_HEADER.value])
+            order_details = outbound.reindex(columns=FILE_TYPES_COLUMNS_MAPPER[UploadFileType.ORDER_DETAILS.value])
+        
+        ## Save dataframes
+        self.item_master = item_master
+        self.inbound_header = inbound_header
+        self.inbound_details = inbound_details
+        self.inventory = inventory
+        self.order_header = order_header
+        self.order_details = order_details
+
+        log_file.flush()
+
+        return True, ''
+
+    def get_df(self, file_type: UploadFileType):
+        match file_type:
+            case UploadFileType.ITEM_MASTER:
+                return self.item_master
+            case UploadFileType.INBOUND_HEADER:
+                return self.inbound_header
+            case UploadFileType.INBOUND_DETAILS:
+                return self.inbound_details
+            case UploadFileType.INVENTORY:
+                return self.inventory
+            case UploadFileType.ORDER_HEADER:
+                return self.order_header
+            case UploadFileType.ORDER_DETAILS:
+                return self.order_details
+
+
+    ''' Helper Functions '''
+
+    def _validate_file_structure(self, file_type: UploadFileType) -> FileValidation:
+        file_path = f'{self.path}/{file_type.value}.csv'
+        required_columns = FILE_TYPES_COLUMNS_MAPPER[file_type.value]
+        print(required_columns)
+        
+        return validate_file_structure(file_type=file_type, file_path=file_path, required_columns=required_columns)
+
+    def _get_header_from_inbound_df(self, inbound_df: pd.DataFrame):
+        inbound_header = inbound_df.groupby('PO_Number').aggregate({
+            'ArrivalDate': 'first', 
+            'ArrivalTime': 'first',
+            'ExpectedDate': 'first', 
+            'ExpectedTime': 'first', 
+            'Carrier': 'first', 
+            'Mode': 'first',
+            'ShipmentNumber': 'first', 
+            'UnloadType': 'first'
+        }).reset_index()
+
+        return inbound_header
+
+    def _get_header_from_outbound_df(self, outbound_df: pd.DataFrame):
+        order_header = outbound_df.groupby('OrderNumber').aggregate({
+            'ReceivedDate': 'first',
+            'PickDate': 'first',
+            'ShipDate': 'first',
+            'Channel': 'first'
+        }).reset_index()
+        
+        return order_header

--- a/data_profiler/helpers/functions/data_file_functions.py
+++ b/data_profiler/helpers/functions/data_file_functions.py
@@ -1,0 +1,123 @@
+'''
+Jack Miller
+Apex Companies
+Sep 2025
+'''
+
+from io import TextIOWrapper
+import os
+import math
+import pandas as pd
+
+from .functions import csv_given_columns, missing_column_names, invalid_column_names, file_path_is_valid_data_frame, data_frame_is_empty
+
+from ..constants.data_file_constants import FILE_TYPES_DTYPES_MAPPER, DTYPES_DEFAULT_VALUES
+from ..models.DataFiles import UploadFileType, FileValidation
+
+
+
+def validate_file_structure( file_type: UploadFileType, file_path: str, required_columns: list, valid_columns: list = None) -> FileValidation:
+    # Start
+    validation_obj = FileValidation(file_type=file_type, file_path=file_path)
+
+    # Is it present?
+    if not os.path.exists(validation_obj.file_path) or os.stat(validation_obj.file_path).st_size == 0:
+        validation_obj.is_present = False
+        validation_obj.is_valid = False
+        validation_obj.file_path = ''
+        return validation_obj
+    else:
+        validation_obj.is_present = True
+
+    # Is it a data frame?
+    if not file_path_is_valid_data_frame(validation_obj.file_path):
+        validation_obj.is_valid = False
+        return validation_obj
+    
+    # Find given columns
+    given_cols = csv_given_columns(file_path=validation_obj.file_path)
+    validation_obj.given_columns = given_cols
+
+    # Does it have all required columns?
+    missing_cols = missing_column_names(given_cols=given_cols, required_cols=required_columns)
+    if missing_cols:
+        validation_obj.is_valid = False
+        validation_obj.missing_columns = missing_cols
+        return validation_obj
+
+    # Does it have any columns it ain't supposed to?
+    if valid_columns:
+        invalid_cols = invalid_column_names(given_cols=given_cols, valid_cols=valid_columns)
+        if invalid_cols:
+            validation_obj.is_valid = False
+            validation_obj.invalid_columns = invalid_cols
+            return validation_obj
+
+    # Is dataframe empty?
+    if data_frame_is_empty(file_path=validation_obj.file_path):     # Empty = headers present but no row data
+        validation_obj.is_present = False
+        return validation_obj
+    
+    # Otherwise, it's valid
+    return validation_obj
+
+def read_and_cleanse_uploaded_data_file(file_type: UploadFileType, file_path: str, log_file: TextIOWrapper = None) -> tuple[pd.DataFrame, list]:
+    ''' 
+    Reads given file and returns a cleansed dataframe. Converts column types to match database and re-order columns. Finds type errors now before attempting DB transactions.
+
+    Return
+    ------
+    pd.DataFrame
+    '''
+
+    if log_file: log_file.write(f'Reading {file_type.value}\n')
+
+    dtypes = FILE_TYPES_DTYPES_MAPPER[file_type.value]
+
+    df = pd.read_csv(file_path)
+    if log_file: log_file.write(f'Shape: {df.shape}\n')
+
+    errors_encountered = 0
+    errors_list = []
+    for col, dtype in dtypes.items():
+        if not col in df.columns:
+            continue
+
+        try:
+            rows_to_fill = 0
+            default_val = DTYPES_DEFAULT_VALUES[dtype]
+
+            if dtype == 'date':
+                df[col] = pd.to_datetime(df[col], dayfirst=True, format='mixed', errors='coerce')
+            elif dtype == 'time':
+                df[col] = pd.to_datetime(df[col], format='%H:%M:%S', errors='coerce')
+            elif dtype == 'float64' or dtype == 'int64':
+                df[col] = pd.to_numeric(df[col], errors='coerce')
+            elif dtype == 'object':
+                df[col] = df[col].astype("string")
+            
+            rows_to_fill = len(df.loc[df[col].isna(), :])
+            df[col] = df[col].replace(to_replace=math.nan, value=default_val)
+            
+            if rows_to_fill > 0:
+                if log_file: log_file.write(f'{col} - replacing erroneous cells with default value "{default_val}" to {rows_to_fill} rows\n')
+
+        except Exception as e:
+            if log_file: log_file.write(f'ERROR - Could not convert field "{col}" to correct type {dtype}: {e}\n')
+            print(f'ERROR converting field "{col}" to correct type: {e}\n')
+            errors_list.append(e)
+            errors_encountered += 1
+
+    if errors_encountered > 0:
+        if log_file: log_file.write(f'{errors_encountered} error(s) encountered converting to correct dtypes.\n\n')
+        print(f'{errors_encountered} error(s) encountered converting to correct dtypes. Quitting before DB insertion.')
+    else:
+        if log_file: log_file.write(f'Dtype conversions successful.\n\n')
+        print(f'Dtype conversions successful.')
+
+    # Reindex for consistent column order
+    df = df.reindex(columns=dtypes.keys())
+
+    if log_file: log_file.flush()
+    
+    return df, errors_list

--- a/data_profiler/helpers/models/DataFiles.py
+++ b/data_profiler/helpers/models/DataFiles.py
@@ -11,16 +11,18 @@ from enum import Enum
 
 from typing import Union
 
-class FileType(Enum):
-# class FileType(BaseModel):
-    BASE_FILE = 'BaseFile'
 
-# class UploadFileTypes(FileType, Enum):
+class DataUploadType(Enum):
+    REGULAR = 1
+    HEADERS = 2
+
 class UploadFileTypes(str, Enum):
     ITEM_MASTER = 'ItemMaster'
+    INBOUND = 'Inbound'
     INBOUND_HEADER = 'InboundHeader'
     INBOUND_DETAILS = 'InboundDetails'
     INVENTORY = 'Inventory'
+    OUTBOUND = 'Outbound'
     ORDER_HEADER = 'OrderHeader'
     ORDER_DETAILS = 'OrderDetails'
     SUBWHSE_UPDATE = 'SubwhseUpdate'
@@ -32,7 +34,6 @@ class OtherFileTypes(str, Enum):
 class UploadedFile(BaseModel):
     file_type: UploadFileTypes
     file_path: str
-
 
 class UploadedFilePaths(BaseModel):
     item_master: str = ''
@@ -55,12 +56,18 @@ class FileValidation(BaseModel):
 
 class DataDirectoryValidation(BaseModel):
     file_path: str
-    is_valid: bool = True
+    data_upload_type: DataUploadType = DataUploadType.REGULAR
     given_files: list = []
+
+    is_valid: bool = True
     errors_list: list = []
+
     item_master: FileValidation = FileValidation(file_type=UploadFileTypes.ITEM_MASTER)
+    inbound: FileValidation = FileValidation(file_type=UploadFileTypes.INBOUND)
+    inventory: FileValidation = FileValidation(file_type=UploadFileTypes.INVENTORY)
+    outbound: FileValidation = FileValidation(file_type=UploadFileTypes.OUTBOUND)
+
     inbound_header: FileValidation = FileValidation(file_type=UploadFileTypes.INBOUND_HEADER)
     inbound_details: FileValidation = FileValidation(file_type=UploadFileTypes.INBOUND_DETAILS)
-    inventory: FileValidation = FileValidation(file_type=UploadFileTypes.INVENTORY)
     order_header: FileValidation = FileValidation(file_type=UploadFileTypes.ORDER_HEADER)
     order_details: FileValidation = FileValidation(file_type=UploadFileTypes.ORDER_DETAILS)

--- a/data_profiler/helpers/models/DataFiles.py
+++ b/data_profiler/helpers/models/DataFiles.py
@@ -12,11 +12,11 @@ from enum import Enum
 from typing import Union
 
 
-class DataUploadType(str, Enum):
+class DataDirectoryType(str, Enum):
     REGULAR = 'Regular'
     HEADERS = 'Headers'
 
-class UploadFileTypes(str, Enum):
+class UploadFileType(str, Enum):
     ITEM_MASTER = 'ItemMaster'
     INBOUND = 'Inbound'
     INBOUND_HEADER = 'InboundHeader'
@@ -32,7 +32,7 @@ class OtherFileTypes(str, Enum):
     SUBWHSE_UPDATE = 'SubwhseUpdate'
 
 class UploadedFile(BaseModel):
-    file_type: UploadFileTypes
+    file_type: UploadFileType
     file_path: str
 
 class UploadedFilePaths(BaseModel):
@@ -48,7 +48,7 @@ class UploadedFilePaths(BaseModel):
 
 
 class FileValidation(BaseModel):
-    file_type: UploadFileTypes
+    file_type: UploadFileType
     file_path: str = ''
     is_present: bool = True
     is_valid: bool = True
@@ -59,18 +59,18 @@ class FileValidation(BaseModel):
 
 class DataDirectoryValidation(BaseModel):
     file_path: str
-    data_upload_type: DataUploadType = DataUploadType.REGULAR
+    data_directory_type: DataDirectoryType = DataDirectoryType.REGULAR
     given_files: list = []
 
     is_valid: bool = True
     errors_list: list = []
 
-    item_master: FileValidation = FileValidation(file_type=UploadFileTypes.ITEM_MASTER)
-    inbound: FileValidation = FileValidation(file_type=UploadFileTypes.INBOUND)
-    inventory: FileValidation = FileValidation(file_type=UploadFileTypes.INVENTORY)
-    outbound: FileValidation = FileValidation(file_type=UploadFileTypes.OUTBOUND)
+    item_master: FileValidation = FileValidation(file_type=UploadFileType.ITEM_MASTER)
+    inbound: FileValidation = FileValidation(file_type=UploadFileType.INBOUND)
+    inventory: FileValidation = FileValidation(file_type=UploadFileType.INVENTORY)
+    outbound: FileValidation = FileValidation(file_type=UploadFileType.OUTBOUND)
 
-    inbound_header: FileValidation = FileValidation(file_type=UploadFileTypes.INBOUND_HEADER)
-    inbound_details: FileValidation = FileValidation(file_type=UploadFileTypes.INBOUND_DETAILS)
-    order_header: FileValidation = FileValidation(file_type=UploadFileTypes.ORDER_HEADER)
-    order_details: FileValidation = FileValidation(file_type=UploadFileTypes.ORDER_DETAILS)
+    inbound_header: FileValidation = FileValidation(file_type=UploadFileType.INBOUND_HEADER)
+    inbound_details: FileValidation = FileValidation(file_type=UploadFileType.INBOUND_DETAILS)
+    order_header: FileValidation = FileValidation(file_type=UploadFileType.ORDER_HEADER)
+    order_details: FileValidation = FileValidation(file_type=UploadFileType.ORDER_DETAILS)

--- a/data_profiler/helpers/models/DataFiles.py
+++ b/data_profiler/helpers/models/DataFiles.py
@@ -12,9 +12,9 @@ from enum import Enum
 from typing import Union
 
 
-class DataUploadType(Enum):
-    REGULAR = 1
-    HEADERS = 2
+class DataUploadType(str, Enum):
+    REGULAR = 'Regular'
+    HEADERS = 'Headers'
 
 class UploadFileTypes(str, Enum):
     ITEM_MASTER = 'ItemMaster'
@@ -37,9 +37,12 @@ class UploadedFile(BaseModel):
 
 class UploadedFilePaths(BaseModel):
     item_master: str = ''
+    inbound: str = ''
+    inventory: str = ''
+    outbound: str = ''
+    
     inbound_header: str = ''
     inbound_details: str = ''
-    inventory: str = ''
     order_header: str = ''
     order_details: str = ''
 

--- a/data_profiler/helpers/models/TransformOptions.py
+++ b/data_profiler/helpers/models/TransformOptions.py
@@ -9,7 +9,7 @@ Transform options models
 from enum import Enum
 from pydantic import BaseModel
 
-from .DataFiles import DataUploadType
+from .DataFiles import DataDirectoryType
 
 class DateForAnalysis(str, Enum):
     RECEIVED_DATE = 'ReceivedDate'
@@ -27,7 +27,7 @@ class WeekendDateRules(str, Enum):
 class TransformOptions(BaseModel):
     date_for_analysis: DateForAnalysis | None = None
     weekend_date_rule: WeekendDateRules | None = None
-    data_upload_type: DataUploadType = DataUploadType.REGULAR
+    data_directory_type: DataDirectoryType = DataDirectoryType.REGULAR
     process_inbound_data: bool = True
     process_inventory_data: bool = True
     process_outbound_data: bool = True

--- a/data_profiler/helpers/models/TransformOptions.py
+++ b/data_profiler/helpers/models/TransformOptions.py
@@ -9,6 +9,7 @@ Transform options models
 from enum import Enum
 from pydantic import BaseModel
 
+from .DataFiles import DataUploadType
 
 class DateForAnalysis(str, Enum):
     RECEIVED_DATE = 'ReceivedDate'
@@ -26,6 +27,7 @@ class WeekendDateRules(str, Enum):
 class TransformOptions(BaseModel):
     date_for_analysis: DateForAnalysis | None = None
     weekend_date_rule: WeekendDateRules | None = None
+    data_upload_type: DataUploadType = DataUploadType.REGULAR
     process_inbound_data: bool = True
     process_inventory_data: bool = True
     process_outbound_data: bool = True


### PR DESCRIPTION
## Notes

### Regular vs. Headers mode
- Toggle in GUI between Regular and Headers upload mode
- Add columns / dtypes / models for regular vs. header upload files
- DataDirectoryType enum

### Create new DataDirectory class in separate file
- Move data directory validation and file reading to new class
- DataProfiler function creates DataDirectory object, calls validation function, then calls read function, then sends it off to the TransformService
   - If any of those functions fail, it returns a notice of the failure to the client

### Move file reading functions to separate helper file

### DataProfilerGUI no longer validates data directory before calling upload function, as upload function already performs validation